### PR TITLE
Keystore key length

### DIFF
--- a/HDWalletKit.podspec
+++ b/HDWalletKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'HDWalletKit'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'Hierarchical Deterministic(HD) wallet for cryptocurrencies'
   
   s.description      = <<-DESC

--- a/HDWalletKit/Keystore/KeystoreV3.swift
+++ b/HDWalletKit/Keystore/KeystoreV3.swift
@@ -14,7 +14,6 @@ public class KeystoreV3: KeystoreInterface {
     public var keystoreParams: KeystoreParamsV3?
     
     public required init? (seed: Data, password: String) throws {
-        guard seed.count == 32 else {return nil}
         try encryptDataToStorage(password, seed: seed)
     }
     
@@ -43,7 +42,6 @@ public class KeystoreV3: KeystoreInterface {
         let derivedKeyLast16bytes = Data(derivedKey[(derivedKey.count - 16)...(derivedKey.count - 1)])
         dataForMAC.append(derivedKeyLast16bytes)
         guard let cipherText = Data.fromHex(keystoreParams.crypto.ciphertext) else {return nil}
-        if (cipherText.count != 32) {return nil}
         dataForMAC.append(cipherText)
         let mac = dataForMAC.sha3(.keccak256)
         guard let calculatedMac = Data.fromHex(keystoreParams.crypto.mac),

--- a/HDWalletKit_Tests/KeystoreTests.swift
+++ b/HDWalletKit_Tests/KeystoreTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class KeystoreTests: XCTestCase {
     
     func testKeyStoreGeneration() {
-        let data = "4e7936ba4a6bf40d0926ac9b0da0208d".data(using: .utf8)!
+        let data = Data(hex: "576896308291575cb5b61eacd178e19721736b63594ee4c9bf60ffd9f3bd869de2124580d9ef0d4446fe467a7014b9894a738780db3c00cde5f86a7922115bdb")
         let keystore = try! KeystoreV3(seed: data, password: "bYSqu6{X")
         XCTAssertEqual(keystore?.keystoreParams?.crypto.cipher, "aes-128-ctr")
         XCTAssertEqual(keystore?.keystoreParams?.crypto.kdf, "scrypt")
@@ -23,7 +23,7 @@ class KeystoreTests: XCTestCase {
     }
     
     func testDecodeKeystore() {
-        let data = "4e7936ba4a6bf40d0926ac9b0da0208d".data(using: .utf8)!
+        let data = Data(hex: "576896308291575cb5b61eacd178e19721736b63594ee4c9bf60ffd9f3bd869de2124580d9ef0d4446fe467a7014b9894a738780db3c00cde5f86a7922115bdb")
         let password = "bYSqu6{X"
         let keystore = try! KeystoreV3(seed: data, password: password)
         guard let decoded = try? keystore?.getDecriptedKeyStore(password: password) else {


### PR DESCRIPTION
### Description
- Remove breaking of generation algorithm when key length is not 32 bytes because a seed is 64 bytes length.